### PR TITLE
Switch from `oath` to Native Promises

### DIFF
--- a/lib/sechash.js
+++ b/lib/sechash.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * sechash
  *
@@ -8,9 +10,9 @@
  * @copyright  Copyright 2012 James Brumond
  * @license    Dual licensed under MIT and GPL
  */
-	
-var oath    = require('oath');
+
 var crypto  = require('crypto');
+var Promise = require('any-promise');
 
 var defaultOptions = {
 	algorithm: 'sha1',
@@ -42,21 +44,24 @@ exports.strongHashSync = function(str, opts) {
 };
 
 exports.strongHash = function(str, opts, callback) {
-	var promise = new oath();
 	if (typeof opts === 'function') {
 		callback = opts;
 		opts = null;
 	}
 	opts = getOptions(opts);
-	asyncFor(opts.iterations, opts.intervalLength,
-		function() {
-			str = hash(opts.algorithm, str + opts.salt);
-		},
-		function() {
-			done(promise, callback, opts.meta + str);
-		}
-	);
-	return promise.promise;
+
+	var promise = new Promise(function(resolve, reject) {
+		asyncFor(opts.iterations, opts.intervalLength,
+			function() {
+				str = hash(opts.algorithm, str + opts.salt);
+			},
+			function() {
+				resolve(opts.meta + str)
+			}
+		);
+	});
+
+	return asCallback(promise, callback);
 };
 
 exports.testHashSync = function(str, hash, opts) {
@@ -65,34 +70,40 @@ exports.testHashSync = function(str, hash, opts) {
 };
 
 exports.testHash = function(str, hash, opts, callback) {
-	var promise = new oath();
 	if (typeof opts === 'function') {
 		callback = opts;
 		opts = null;
 	}
 	opts = getOptions(opts, hash);
-	exports.strongHash(str, opts, function(err, result) {
-		done(promise, callback, hash === result);
+
+	var promise = new Promise(function(resolve, reject) {
+		exports.strongHash(str, opts, function(err, result) {
+			if (err) return reject(err);
+			resolve(hash === result);
+		});
 	});
-	return promise.promise;
+
+	return asCallback(promise, callback);
 };
 
 
 
 // ------------------------------------------------------------------
 //  Helpers
+function asCallback(promise, callback) {
+	if (typeof callback !== 'function') return promise;
+
+	return promise.then(function(result) {
+		callback(null, result);
+	}, function(reason) {
+		callback(reason);
+	});
+}
 
 function hash(alg, str) {
 	var hashsum = crypto.createHash(alg);
 	hashsum.update(str);
 	return hashsum.digest('hex');
-}
-
-function done(promise, callback, result) {
-	if (typeof callback === 'function') {
-		callback(null, result);
-	}
-	promise.resolve(result);
 }
 
 function getOptions(opts, hash) {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"test": "mocha test/"
 	},
 	"dependencies": {
-		"oath": "0.2.3"
+		"any-promise": "^1.3.0"
 	},
   "devDependencies": {
     "mocha": "^3.1.2"

--- a/package.json
+++ b/package.json
@@ -11,8 +11,13 @@
 	"engines": {
 		"node": "*"
 	},
+	"scripts": {
+		"test": "mocha test/"
+	},
 	"dependencies": {
 		"oath": "0.2.3"
 	},
-	"devDependencies": { }
+  "devDependencies": {
+    "mocha": "^3.1.2"
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -93,6 +93,78 @@ describe('sechash', function() {
 			});
 		});
 
+		describe('promise-based', function() {
+			FIXTURES.forEach(function(fixture) {
+				describe(fixture.algorithm, function() {
+
+					function performPromiseTests(opts) {
+						var string = 'Your String';
+						var hash;
+						return sechash.strongHash(string)
+							.then(function(_hash) {
+								hash = _hash;
+
+								return sechash.testHash(string, hash)
+							})
+							.then(function(result) {
+								assert.strictEqual(result, true);
+
+								return sechash.testHash(string, hash + '1');
+							})
+							.then(function(result) {
+								assert.strictEqual(result, false);
+
+								return sechash.testHash(string, '1' + hash);
+							})
+							.then(function(result) {
+								assert.strictEqual(result, false);
+
+								return sechash.testHash('Another string', hash);
+							})
+							.then(function(result) {
+								assert.strictEqual(result, false);
+							});
+					}
+					it('using default options', function() {
+						var opts = {
+							algorithm: fixture.algorithm
+						};
+
+						return performPromiseTests(opts);
+					});
+
+					it('using non-default options', function() {
+						var opts = {
+							algorithm: fixture.algorithm,
+							iterations: 2000,
+							salt: 'some salt string'
+						};
+
+						return performPromiseTests(opts);
+					});
+
+					it('includeMeta on', function() {
+						var opts = {
+							algorithm: fixture.algorithm,
+							includeMeta: true
+						};
+
+						return performPromiseTests(opts);
+					});
+
+					it('includeMeta off', function() {
+						var opts = {
+							algorithm: fixture.algorithm,
+							includeMeta: false
+						};
+
+						return performPromiseTests(opts);
+					});
+
+				});
+			});
+		});
+
 		describe('callback-based', function() {
 			FIXTURES.forEach(function(fixture) {
 				describe(fixture.algorithm, function() {


### PR DESCRIPTION
Depends on: Add more tests #3

This PR switches `sechash` from `oath` to native promises.

In environments where native promises are not supported (eg, node 10), [`any-promise`](https://github.com/kevinbeaty/any-promise) is used to resolve another promise library.